### PR TITLE
Extended the external C API to accept vector of vectors as well

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -31,7 +31,33 @@ end
 function ModelicaStandardTables_CombiTable1D_init2(
   fileName::String,
   tableName::String,
-  table::Vector{Float64},
+  table::Vector{Vector{Float64}},
+  nRow::Int64,
+  nColumn::Int64,
+  columns::Vector{Int64},
+  nCols::Int64,
+  smoothness::Int64,
+  extrapolation::Int64,
+  verbose::Int64 = 1)
+  #= Requires Julia > 1.9 =#
+  local tableM = stack(table)
+  ModelicaStandardTables_CombiTable1D_init2(
+    fileName,
+    tableName,
+    tableM,
+    nRow,
+    nColumn,
+    columns,
+    nCols,
+    smoothness,
+    extrapolation,
+    verbose)
+end
+
+function ModelicaStandardTables_CombiTable1D_init2(
+  fileName::String,
+  tableName::String,
+  table::Matrix{Float64},
   nRow::Int64,
   nColumn::Int64,
   columns::Vector{Int64},
@@ -39,10 +65,11 @@ function ModelicaStandardTables_CombiTable1D_init2(
   smoothness::Int64,
   extrapolation::Int64,
   verbose::Int64 = 1)::Any
+  #= Converts the table into the C format, that is double* =#
+  local tableCShape = reduce(vcat, [table[j,i] for i in 1:size(table,2), j in 1:size(table,1)])
   local res = ccall((:ModelicaStandardTables_CombiTable1D_init2, installedLibPath), Ptr{Cvoid},
                 (Cstring, Cstring, Ptr{Cdouble}, Csize_t, Csize_t, Ptr{Cint}, Csize_t, Cint, Cint, Cint),
-                fileName, tableName, table, nRow, nColumn, columns, nCols, smoothness, extrapolation, verbose)
-#  @show res
+                    fileName, tableName, tableCShape, nRow, nColumn, columns, nCols, smoothness, extrapolation, verbose)
   res
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,8 +32,8 @@ function callExternalTable()
   local verbose::Int64 = 1
   local fileName::String = "NoName"
   local tableName::String = "NoName"
-  local tableCShape = reduce(vcat, [table[j,i] for i in 1:size(table,2), j in 1:size(table,1)])
-  OMRuntimeExternalC.ModelicaStandardTables_CombiTable1D_init2(fileName, tableName, tableCShape, size(table,1), size(table,2), columns, size(columns,1), LinearSegments, LastTwoPoints, verbose)
+  #local tableCShape = reduce(vcat, [table[j,i] for i in 1:size(table,2), j in 1:size(table,1)])
+  OMRuntimeExternalC.ModelicaStandardTables_CombiTable1D_init2(fileName, tableName, table, size(table,1), size(table,2), columns, size(columns,1), LinearSegments, LastTwoPoints, verbose)
 end
 
 @testset "Test the Modelica external C API" begin
@@ -69,6 +69,32 @@ end
     catch
       false
     end
+  end
+  #= Test that the API can be called with a vector of vectors as well. =#
+  local vec0 = [1.1, 1.2]
+  local vec1 = [1.1, 1.2]
+  local vecVec::Vector{Vector{Float64}} = [vec0, vec1]
+  local columns::Vector{Int64} = [2]
+  local LinearSegments::Int64 = 1
+  local LastTwoPoints::Int64 = 2
+  local verbose::Int64 = 1
+  local fileName::String = "NoName"
+  local tableName::String = "NoName"
+  local id2 = OMRuntimeExternalC.ModelicaStandardTables_CombiTable1D_init2(fileName,
+                                                                           tableName,
+                                                                           vecVec,
+                                                                           2,
+                                                                           2,
+                                                                           columns,
+                                                                           LinearSegments,
+                                                                           LastTwoPoints,
+                                                                           verbose)
+  @test 1.2 == begin
+    OMRuntimeExternalC.ModelicaStandardTables_CombiTable1D_maximumAbscissa(id2)
+  end
+
+  @test 1.1 == begin
+    OMRuntimeExternalC.ModelicaStandardTables_CombiTable1D_minimumAbscissa(id2)
   end
 
 end


### PR DESCRIPTION
Added an option to pass `table::Vector{Vector{Float64}}` to the function initializing the table