### PR TITLE
Pre-load OMC shared libraries by absolute path in topological order

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OMRuntimeExternalC"
 uuid = "ada38df0-e20e-11ed-02f3-2b4b19c1ec8a"
 authors = ["Adrian Pop <adrian.pop@liu.se>", "John Tinnerholm <john.tinnerholm@liu.se>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/src/OMRuntimeExternalC.jl
+++ b/src/OMRuntimeExternalC.jl
@@ -34,37 +34,49 @@ function locateSharedParserLibrary(directoryToSearchIn, libraryName, relativeDir
   nothing
 end
 
+#= Topological load order for the OMC shared libraries shipped with this
+   package. Each entry only references SONAMEs of entries that appear before
+   it, so dlopen'ing them in this sequence with RTLD_GLOBAL satisfies every
+   DT_NEEDED reference for the dependent libraries. libModelicaCallbacks is
+   first so its symbols win global resolution and override the default OMC
+   setjmp/longjmp-based error handlers. =#
+const _LIB_LOAD_ORDER = (
+  "libModelicaCallbacks",
+  "libomcgc",
+  "libOpenModelicaRuntimeC",
+  "libModelicaMatIO",
+  "libModelicaIO",
+  "libModelicaStandardTables",
+  "libModelicaExternalC",
+  "libSimulationRuntimeC",
+)
+
 function __init__()
-  try
-    if installedLibPath !== nothing
-      local libdir = splitdir(installedLibPath)[1]
-      if Sys.iswindows()
-        #= On Windows, add to PATH for DLL search =#
-        Base._setenv("PATH", ENV["PATH"] * ";" * libdir)
-      else
-        #= On Linux/macOS, add to both DL_LOAD_PATH and LD_LIBRARY_PATH =#
-        push!(Libdl.DL_LOAD_PATH, libdir)
-        #= Also set LD_LIBRARY_PATH for library dependencies loaded by the system linker =#
-        local ldpath = get(ENV, "LD_LIBRARY_PATH", "")
-        ENV["LD_LIBRARY_PATH"] = isempty(ldpath) ? libdir : libdir * ":" * ldpath
+  if installedLibPath === nothing
+    @warn "OMRuntimeExternalC: shared libraries not found. Simulations that use external Modelica functions will fail."
+    return nothing
+  end
+  local libdir = splitdir(installedLibPath)[1]
+  push!(Libdl.DL_LOAD_PATH, libdir)
+  if Sys.iswindows()
+    #= Windows resolves DLL dependencies via PATH at LoadLibrary time. =#
+    ENV["PATH"] = libdir * ";" * get(ENV, "PATH", "")
+  end
+  #= The prebuilt .so files have RUNPATH baked to the original build host,
+     so ld.so cannot resolve inter-library DT_NEEDED entries on its own.
+     Pre-load every dependency by absolute path in topological order with
+     RTLD_GLOBAL; ld.so reuses the already-loaded library when it sees the
+     same SONAME on a dependent load. =#
+  local ext = Sys.iswindows() ? ".dll" : (Sys.isapple() ? ".dylib" : ".so")
+  for name in _LIB_LOAD_ORDER
+    local p = joinpath(libdir, name * ext)
+    if isfile(p)
+      try
+        Libdl.dlopen(p, Libdl.RTLD_GLOBAL | Libdl.RTLD_LAZY)
+      catch err
+        @warn "OMRuntimeExternalC: failed to preload $name" path=p exception=err
       end
     end
-    #= Load the Julia-compatible ModelicaCallbacks shim FIRST with RTLD_GLOBAL
-       so it overrides the OMC setjmp/longjmp-based error handlers.
-       Then load the other libraries with RTLD_GLOBAL so their symbols are
-       visible to dlsym (used by the safe_* wrappers in the callbacks shim). =#
-    if installedLibPathlibModelicaCallbacks !== nothing
-      Libdl.dlopen(installedLibPathlibModelicaCallbacks, Libdl.RTLD_GLOBAL)
-    end
-    if installedLibPathlibModelicaIO !== nothing
-      Libdl.dlopen(installedLibPathlibModelicaIO, Libdl.RTLD_GLOBAL)
-    end
-    if installedLibPathlibModelicaExternalC !== nothing
-      Libdl.dlopen(installedLibPathlibModelicaExternalC, Libdl.RTLD_GLOBAL)
-    end
-  catch
-    @warn "Failed to setup the environment correctly. Make sure that you have the correct shared libraries installed."
-    @warn "NOTE: If your Modelica model uses certain external functions your simulation might fail."
   end
   nothing
 end


### PR DESCRIPTION
## Problem

Tests in `JKRT/OM.jl` PR #44 (and any other downstream consumer of `OMRuntimeExternalC.jl` on Linux CI) fail with:

```
could not load library ".../libModelicaStandardTables.so"
libModelicaIO.so: cannot open shared object file: No such file or directory
```

even though `libModelicaIO.so` exists next to `libModelicaStandardTables.so` in `lib/ext/shared/x86_64-linux-gnu/`. Knock-on effect is 8 errored tests under `OMRuntimeExternalC API` and 10+ errored / failed tests under `externalBuiltinTests.jl` and downstream IMTK simulate paths in `JKRT/OM.jl` CI.

## Root cause

Every `.so` in the `libs-v0.1.0` release zip has its `DT_RUNPATH` baked to the original build host:

```
$ readelf -d libModelicaStandardTables.so | grep RUNPATH
RUNPATH  /home/johti17/Projects/OpenModelica/build_cmake/OMCompiler/SimulationRuntime/ModelicaExternalC:...
```

That path does not exist on consumer machines, so ld.so cannot resolve inter-library `DT_NEEDED` references on its own. The previous `__init__` only pre-loaded `libModelicaCallbacks`, `libModelicaIO` and `libModelicaExternalC`, leaving `libOpenModelicaRuntimeC`, `libomcgc`, `libModelicaMatIO`, `libModelicaStandardTables` and `libSimulationRuntimeC` unresolved.

The `ENV["LD_LIBRARY_PATH"]` mutation in the old `__init__` is ineffective on Linux because glibc's ld.so caches `LD_LIBRARY_PATH` at process start.

## Fix

Pre-load every shipped library by absolute path with `RTLD_GLOBAL` in a fixed topological order:

```
libModelicaCallbacks
libomcgc
libOpenModelicaRuntimeC
libModelicaMatIO
libModelicaIO
libModelicaStandardTables
libModelicaExternalC
libSimulationRuntimeC
```

ld.so reuses the already-loaded library when it sees the same SONAME on a dependent load, so DT_NEEDED references are satisfied without relying on RUNPATH or `LD_LIBRARY_PATH`. SONAMEs in the release zip match the DT_NEEDED entries verbatim, so reuse is guaranteed.

`libModelicaCallbacks` is still loaded first so its symbols win global resolution and override the default OMC setjmp/longjmp-based error handlers.

## Test evidence

Reproduced with the `libs-v0.1.0` release zip on Linux x86_64, Julia 1.12.6:

Before (upstream master):

```
Attempting dlopen of: .../libModelicaStandardTables.so
FAILED: could not load library ".../libModelicaStandardTables.so"
libModelicaIO.so: cannot open shared object file: No such file or directory
```

After this PR:

```
Attempting dlopen of: .../libModelicaStandardTables.so
OK, handle = Ptr{Nothing}(0x0000000025f84850)
```

Identical error string in the before-state to what `JKRT/OM.jl` PR #44 CI emits.

## Follow-ups not in this PR

- The release-side fix (rebuild the prebuilt libs with `-Wl,-rpath,'$ORIGIN' -Wl,--enable-new-dtags`) is still worth doing eventually so the package does not have to babysit ld.so. This PR makes the Julia-side correct regardless.
- The `libs-v0.1.0` release ships `libomcgc.so` but `pathSetup.jl` does not track it; the new `__init__` locates it by name from `libdir`, which keeps the change minimal. Tracking it in `pathSetup.jl` can come later if anything else needs to reference the path.
- The 404 for `x86_64-linux-gnu-callbacks.tar.gz` in `build.jl` is a separate, pre-existing release-artifact gap (local fallback handles it but should be cleaned up).

Refs JKRT/OM.jl#44